### PR TITLE
Add keys_with_prefix and iterkeys_with_prefix methods

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Authors & Contributors
 ----------------------
 
 * Mikhail Korobov <kmike84@gmail.com>
+* Felix Liu <numeca.yfliu@gmail.com>
 
 This module is based on `hat-trie`_ C library by Daniel Jones & contributors.
 

--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,8 @@ Currently implemented methods are:
 * setdefault()
 * keys()
 * iterkeys()
+* keys_with_prefix()
+* iterkeys_with_prefix()
 
 Other methods are not implemented.
 

--- a/hat-trie/.gitignore
+++ b/hat-trie/.gitignore
@@ -1,0 +1,11 @@
+*.m4
+*.o
+*.lo
+*.a
+*.la
+config.*
+.DS_Store
+.deps
+.libs
+Makefile
+

--- a/hat-trie/src/ahtable.c
+++ b/hat-trie/src/ahtable.c
@@ -14,7 +14,7 @@
 
 
 const double ahtable_max_load_factor = 100000.0; /* arbitrary large number => don't resize */
-const const size_t ahtable_initial_size = 4096;
+const size_t ahtable_initial_size = 4096;
 static const uint16_t LONG_KEYLEN_MASK = 0x7fff;
 
 static size_t keylen(slot_t s) {

--- a/hat-trie/src/hat-trie.h
+++ b/hat-trie/src/hat-trie.h
@@ -33,6 +33,9 @@ void       hattrie_free   (hattrie_t*);       //< Free all memory used by a trie
 hattrie_t* hattrie_dup    (const hattrie_t*); //< Duplicate an existing trie.
 void       hattrie_clear  (hattrie_t*);       //< Remove all entries.
 
+/** number of inserted keys
+ */
+size_t hattrie_size (hattrie_t*);
 
 /** Find the given key in the trie, inserting it if it does not exist, and
  * returning a pointer to it's key.
@@ -43,10 +46,21 @@ void       hattrie_clear  (hattrie_t*);       //< Remove all entries.
  */
 value_t* hattrie_get (hattrie_t*, const char* key, size_t len);
 
-
 /** Find a given key in the table, returning a NULL pointer if it does not
  * exist. */
 value_t* hattrie_tryget (hattrie_t*, const char* key, size_t len);
+
+/** hattrie_walk callback signature */
+typedef int (*hattrie_walk_cb)(const char* key, size_t len, value_t* val, void* user_data);
+
+/** hattrie_walk callback return values, controls whether should stop the walk or not */
+#define hattrie_walk_stop 0
+#define hattrie_walk_continue 1
+
+/** Find stored keys which are prefices of key, and invoke callback for every found key and val.
+ *  The invocation order is: short key to long key.
+ */
+void hattrie_walk (hattrie_t*, const char* key, size_t len, void* user_data, hattrie_walk_cb);
 
 /** Delete a given key from trie. Returns 0 if successful or -1 if not found.
  */
@@ -61,10 +75,12 @@ void            hattrie_iter_free      (hattrie_iter_t*);
 const char*     hattrie_iter_key       (hattrie_iter_t*, size_t* len);
 value_t*        hattrie_iter_val       (hattrie_iter_t*);
 
+/** Note the hattrie_iter_key() for prefixed search gets the suffix instead of the whole key
+ */
+hattrie_iter_t* hattrie_iter_with_prefix(const hattrie_t*, bool sorted, const char* prefix, size_t prefix_len);
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-
-

--- a/src/chat_trie.pxd
+++ b/src/chat_trie.pxd
@@ -25,12 +25,12 @@ cdef extern from "../hat-trie/src/hat-trie.h":
     ctypedef struct hattrie_iter_t:
         pass
 
-    hattrie_iter_t* hattrie_iter_begin     (hattrie_t*, bint sorted)
-    void            hattrie_iter_next      (hattrie_iter_t*)
-    bint            hattrie_iter_finished  (hattrie_iter_t*)
-    void            hattrie_iter_free      (hattrie_iter_t*)
-    char*           hattrie_iter_key       (hattrie_iter_t*, size_t* len)
-    value_t*        hattrie_iter_val       (hattrie_iter_t*)
+    hattrie_iter_t* hattrie_iter_with_prefix (hattrie_t*, bint sorted, char* prefix, size_t prefix_len)
+    void            hattrie_iter_next        (hattrie_iter_t*)
+    bint            hattrie_iter_finished    (hattrie_iter_t*)
+    void            hattrie_iter_free        (hattrie_iter_t*)
+    char*           hattrie_iter_key         (hattrie_iter_t*, size_t* len)
+    value_t*        hattrie_iter_val         (hattrie_iter_t*)
 
 cdef struct hattrie_t_:
     void* root

--- a/src/hat_trie.pyx
+++ b/src/hat_trie.pyx
@@ -113,7 +113,7 @@ cdef class Trie(BaseTrie):
 
     def setdefault(self, unicode key, int value):
         cdef bytes bkey = key.encode('utf8')
-        self._setdefault(bkey, value)
+        return self._setdefault(bkey, value)
 
     def keys(self):
         return [key.decode('utf8') for key in self.iterkeys()]

--- a/src/hat_trie.pyx
+++ b/src/hat_trie.pyx
@@ -32,31 +32,10 @@ cdef class BaseTrie:
     def setdefault(self, bytes key, int value):
         return self._setdefault(key, value)
 
-    def keys(self):
-        return list(self.iterkeys())
+    def keys(self, prefix = ''):
+        return list(self.iterkeys(prefix))
 
-    def iterkeys(self):
-        cdef:
-            hattrie_iter_t* it = hattrie_iter_with_prefix(self._trie, 0, NULL, 0)
-            char* c_key
-            size_t val
-            size_t length
-            bytes py_str
-
-        try:
-            while not hattrie_iter_finished(it):
-                c_key = hattrie_iter_key(it, &length)
-                py_str = c_key[:length]
-                yield py_str
-                hattrie_iter_next(it)
-
-        finally:
-            hattrie_iter_free(it)
-
-    def keys_with_prefix(self, prefix):
-        return list(self.iterkeys_with_prefix(prefix))
-
-    def iterkeys_with_prefix(self, prefix):
+    def iterkeys(self, prefix = ''):
         cdef:
             hattrie_iter_t* it = hattrie_iter_with_prefix(self._trie, 0, prefix, len(prefix))
             char* c_key
@@ -73,7 +52,6 @@ cdef class BaseTrie:
 
         finally:
             hattrie_iter_free(it)
-
 
     cdef int _getitem(self, char* key) except -1:
         cdef value_t* value_ptr = hattrie_tryget(self._trie, key, len(key))
@@ -136,8 +114,5 @@ cdef class Trie(BaseTrie):
         cdef bytes bkey = key.encode('utf8')
         return self._setdefault(bkey, value)
 
-    def keys(self):
-        return [key.decode('utf8') for key in self.iterkeys()]
-        
-    def keys_with_prefix(self, prefix):
-        return [key.decode('utf8') for key in self.iterkeys_with_prefix(prefix)]
+    def keys(self, prefix = ''):
+        return [key.decode('utf8') for key in self.iterkeys(prefix)]


### PR DESCRIPTION
I noticed that luikore/hat-trie version adds some methods like hattrie_iter_with_prefix based on  dcjones/hat-trie version, so I replace the dcjones/hat-trie with luikore/hat-trie version, and add keys_with_prefix and iterkeys_with_prefix methods based on hattrie_iter_with_prefix. I dont know if want to have such a change? if not,  please ignore it.
