### PR TITLE
Fix URLs to point at right repos.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,8 @@ Contributing
 
 Development happens at github and bitbucket:
 
-* https://github.com/kmike/datrie
-* https://bitbucket.org/kmike/datrie
+* https://github.com/kmike/hat-trie
+* https://bitbucket.org/kmike/hat-trie
 
 The main issue tracker is at github.
 


### PR DESCRIPTION
The README is for hat-trie, and so I think these URLs are intended to point at its repo and not datrie's.
